### PR TITLE
Cambio nombre cartas

### DIFF
--- a/QuizAD/src/main/java/org/example/models/Card.java
+++ b/QuizAD/src/main/java/org/example/models/Card.java
@@ -1,7 +1,7 @@
 package org.example.models;
 
 public class Card {
-    public enum Suit { HEARTS, DIAMONDS, CLUBS, SPADES }
+    public enum Suit { HEARTS, DIAMONDS, CLUBS, CLOVERS }
     public enum Rank { TWO, THREE, FOUR, FIVE, SIX, SEVEN, EIGHT, NINE, TEN, JACK, QUEEN, KING, ACE }
 
     private final Suit suit;


### PR DESCRIPTION
Algunos nombres de cartas no coinciden con los nombres adecuados para el tipo de juegos, se cambio el nombre "SPADES"  por "CLOVERS".